### PR TITLE
Change private Google Calendar to public Facebook Events

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,8 @@
 
 
     <body>
+        <div id="fb-root"></div>
+        <script async defer crossorigin="anonymous" src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.3"></script>
 
         <header></header>
 

--- a/views/content/calendar.html
+++ b/views/content/calendar.html
@@ -1,7 +1,6 @@
 <div class="wrapper">
 
-    <iframe src="https://calendar.google.com/calendar/embed?title=DSA%20Cincy%20Calendar&amp;showTitle=0&amp;showCalendars=0&amp;height=600&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=dsacincy%40gmail.com&amp;color=%23711616&amp;ctz=America%2FNew_York"
-        style="border-width:0" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+    <div class="fb-page" data-href="https://www.facebook.com/DSACincy/" data-tabs="events" data-width="500" data-height="" data-small-header="true" data-adapt-container-width="false" data-hide-cover="false" data-show-facepile="false"><blockquote cite="https://www.facebook.com/DSACincy/" class="fb-xfbml-parse-ignore"><a href="https://www.facebook.com/DSACincy/">DSA of Metro Cincinnati &amp; Northern Kentucky</a></blockquote></div>
 
 </div>
 <!-- <footer></footer> -->


### PR DESCRIPTION
Fixes issue #18 on a temporary basis. Will consult with the EC on #15 later if we do want to use Google Calendar on the website.